### PR TITLE
update to allow working with vagrant-libvirt

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -220,7 +220,7 @@ end
         list_of_vms = []
         if vagrant_list != ''
           vagrant_list.each_line do |line|
-            if match = /([\w-]+[\s]+)(created|aborted|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\)|\(vmware_fusion\))/.match(line)
+            if match = /([\w-]+[\s]+)(created|aborted|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\)|\(vmware_fusion\)|\(libvirt\))/.match(line)
               list_of_vms << match[1].strip!
             end
           end


### PR DESCRIPTION
Alter the regex that is used for finding vagrant machines so that it picks up libvirt boxes 